### PR TITLE
feat: VM agent NATS listener with health evaluation and system comments

### DIFF
--- a/src/Console/Commands/ListenVmAgentEvents.php
+++ b/src/Console/Commands/ListenVmAgentEvents.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace NextDeveloper\IAAS\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+use NextDeveloper\Commons\Database\GlobalScopes\LimitScope;
+use NextDeveloper\Commons\Services\CommentsService;
+use NextDeveloper\Events\Services\NatsService;
+use NextDeveloper\IAAS\Database\Models\VirtualMachines;
+use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
+use NextDeveloper\IAM\Helpers\UserHelper;
+
+/**
+ * Subscribes to agent.vm.> and evaluates incoming telemetry for health problems.
+ *
+ * Telemetry is published directly to vm.{uuid}.telemetry by the Go agent, so
+ * this listener does NOT republish. It only reacts when a threshold is breached.
+ *
+ * Usage:
+ *   php artisan iaas:vm-agent-listen
+ *
+ * Requires NATS_ENABLED=true in .env.
+ */
+class ListenVmAgentEvents extends Command
+{
+    protected $signature   = 'iaas:vm-agent-listen';
+    protected $description = 'Listen to VM agent NATS events and alert on health problems';
+
+    private bool $shouldQuit = false;
+
+    // Thresholds — percentages above which a warning is raised
+    private const THRESHOLD_CPU_PCT    = 90.0;
+    private const THRESHOLD_MEMORY_PCT = 90.0;
+    private const THRESHOLD_DISK_PCT   = 85.0;
+
+    public function handle(NatsService $nats): int
+    {
+        if (!config('events.nats.enabled', false)) {
+            $this->error('NATS is not enabled. Set NATS_ENABLED=true in your .env file.');
+            return 1;
+        }
+
+        $this->registerSignalHandlers();
+
+        $nats->subscribe('agent.vm.>', function (array|string $payload, string $subject) {
+            if (!is_array($payload) || ($payload['type'] ?? '') !== 'telemetry') {
+                return;
+            }
+
+            $this->evaluateHealth($payload);
+        });
+
+        $this->info('Subscribed to agent.vm.> — evaluating telemetry for health problems. Press Ctrl+C to stop.');
+
+        while (!$this->shouldQuit) {
+            try {
+                $nats->process(0.1);
+            } catch (\Throwable $e) {
+                if (str_contains($e->getMessage(), 'Interrupted system call')) {
+                    break;
+                }
+                throw $e;
+            }
+            pcntl_signal_dispatch();
+        }
+
+        $this->info('Listener stopped.');
+        return 0;
+    }
+
+    private function evaluateHealth(array $payload): void
+    {
+        $agentUuid = $payload['agent_uuid'] ?? 'unknown';
+        $data      = $payload['payload']    ?? [];
+        $problems  = [];
+
+        $cpu = $data['cpu'] ?? [];
+        if (isset($cpu['usage_pct']) && $cpu['usage_pct'] >= self::THRESHOLD_CPU_PCT) {
+            $problems[] = sprintf('High CPU: %.1f%%', $cpu['usage_pct']);
+        }
+
+        $memory = $data['memory'] ?? [];
+        if (isset($memory['usage_pct']) && $memory['usage_pct'] >= self::THRESHOLD_MEMORY_PCT) {
+            $problems[] = sprintf('High memory: %.1f%%', $memory['usage_pct']);
+        }
+
+        foreach ($data['disks'] ?? [] as $disk) {
+            if (isset($disk['usage_pct']) && $disk['usage_pct'] >= self::THRESHOLD_DISK_PCT) {
+                $problems[] = sprintf(
+                    'High disk on %s: %.1f%%',
+                    $disk['mountpoint'] ?? $disk['device'] ?? '?',
+                    $disk['usage_pct']
+                );
+            }
+        }
+
+        if (empty($problems)) {
+            // VM is healthy — discard
+            return;
+        }
+
+        Log::warning('[ListenVmAgentEvents] VM health problem detected', [
+            'agent_uuid' => $agentUuid,
+            'problems'   => $problems,
+        ]);
+
+        $vm = VirtualMachines::withoutGlobalScope(AuthorizationScope::class)
+            ->withoutGlobalScope(LimitScope::class)
+            ->where('uuid', $agentUuid)
+            ->first();
+
+        if (!$vm) {
+            Log::warning('[ListenVmAgentEvents] VM not found for agent', ['agent_uuid' => $agentUuid]);
+            return;
+        }
+
+        UserHelper::setAdminAsCurrentUser();
+
+        foreach ($problems as $problem) {
+            CommentsService::createSystemComment($problem, $vm);
+        }
+    }
+
+    private function registerSignalHandlers(): void
+    {
+        if (!extension_loaded('pcntl')) {
+            return;
+        }
+
+        pcntl_async_signals(true);
+        pcntl_signal(SIGTERM, fn () => $this->shouldQuit = true);
+        pcntl_signal(SIGINT,  fn () => $this->shouldQuit = true);
+    }
+}

--- a/src/IAASServiceProvider.php
+++ b/src/IAASServiceProvider.php
@@ -117,6 +117,7 @@ class IAASServiceProvider extends AbstractServiceProvider {
                 \NextDeveloper\IAAS\Console\Commands\SyncStorageVolume::class,
                 \NextDeveloper\IAAS\Console\Commands\MigrateVirtualMachine::class,
                 \NextDeveloper\IAAS\Console\Commands\MigrateLocalVirtualMachine::class,
+                \NextDeveloper\IAAS\Console\Commands\ListenVmAgentEvents::class,
             ]);
         }
     }


### PR DESCRIPTION
## Summary

- New `iaas:vm-agent-listen` Artisan command subscribes to `agent.vm.>` and evaluates incoming telemetry for health problems
- Thresholds: CPU >90%, memory >90%, disk >85%
- Healthy telemetry is discarded silently
- Problems trigger `Log::warning` and a system comment on the `VirtualMachines` record via `CommentsService::createSystemComment`
- The Go agent publishes telemetry directly to `vm.{uuid}.telemetry` (client-facing) — no platform relay needed
- Registered in `IAASServiceProvider`

## Test plan

- [ ] Run `php artisan iaas:vm-agent-listen` — subscribes without error
- [ ] Send telemetry with `cpu.usage_pct: 95` — `Log::warning` fires, system comment created on VM
- [ ] Send healthy telemetry — no output, no comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)