### PR TITLE
feat: per-core CPU and disk I/O health checks

### DIFF
--- a/src/Console/Commands/ListenVmAgentEvents.php
+++ b/src/Console/Commands/ListenVmAgentEvents.php
@@ -30,9 +30,10 @@ class ListenVmAgentEvents extends Command
     private bool $shouldQuit = false;
 
     // Thresholds — percentages above which a warning is raised
-    private const THRESHOLD_CPU_PCT    = 90.0;
-    private const THRESHOLD_MEMORY_PCT = 90.0;
-    private const THRESHOLD_DISK_PCT   = 85.0;
+    private const THRESHOLD_CPU_PCT     = 90.0;
+    private const THRESHOLD_MEMORY_PCT  = 90.0;
+    private const THRESHOLD_DISK_PCT    = 85.0;
+    private const THRESHOLD_DISK_IO_PCT = 90.0;
 
     public function handle(NatsService $nats): int
     {
@@ -80,18 +81,27 @@ class ListenVmAgentEvents extends Command
             $problems[] = sprintf('High CPU: %.1f%%', $cpu['usage_pct']);
         }
 
+        foreach ($cpu['cores'] ?? [] as $core) {
+            if (isset($core['usage_pct']) && $core['usage_pct'] >= self::THRESHOLD_CPU_PCT) {
+                $problems[] = sprintf('High CPU on core %d: %.1f%%', $core['id'], $core['usage_pct']);
+            }
+        }
+
         $memory = $data['memory'] ?? [];
         if (isset($memory['usage_pct']) && $memory['usage_pct'] >= self::THRESHOLD_MEMORY_PCT) {
             $problems[] = sprintf('High memory: %.1f%%', $memory['usage_pct']);
         }
 
         foreach ($data['disks'] ?? [] as $disk) {
+            $label = $disk['mountpoint'] ?? $disk['device'] ?? '?';
+
             if (isset($disk['usage_pct']) && $disk['usage_pct'] >= self::THRESHOLD_DISK_PCT) {
-                $problems[] = sprintf(
-                    'High disk on %s: %.1f%%',
-                    $disk['mountpoint'] ?? $disk['device'] ?? '?',
-                    $disk['usage_pct']
-                );
+                $problems[] = sprintf('High disk usage on %s: %.1f%%', $label, $disk['usage_pct']);
+            }
+
+            $ioUtil = $disk['io']['util_pct'] ?? null;
+            if ($ioUtil !== null && $ioUtil >= self::THRESHOLD_DISK_IO_PCT) {
+                $problems[] = sprintf('High disk I/O on %s: %.1f%% utilisation', $label, $ioUtil);
             }
         }
 


### PR DESCRIPTION
## Summary

- Per-core CPU health check: iterates `cpu.cores[]` and flags any core with `usage_pct >= 90%`
- Disk I/O health check: checks `disks[].io.util_pct >= 90%` per partition
- New `THRESHOLD_DISK_IO_PCT = 90.0` constant
- Both fields are optional — absent keys are silently skipped (Go agent uses `omitempty`)
- Each problem generates its own system comment on the `VirtualMachines` record

## Test plan

- [ ] Send telemetry with `cpu.cores[1].usage_pct: 95` — system comment created for that core
- [ ] Send telemetry with `disks[0].io.util_pct: 92` — system comment created for that disk
- [ ] Send telemetry without `cores` or `io` keys — no errors, no comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)