### PR TITLE
fix: remove getConsoleData() from transformer and guard against empty console IV

### DIFF
--- a/src/Http/Transformers/VirtualMachinesTransformer.php
+++ b/src/Http/Transformers/VirtualMachinesTransformer.php
@@ -7,7 +7,7 @@ use League\Fractal\ParamBag;
 use NextDeveloper\Commons\Common\Cache\CacheHelper;
 use NextDeveloper\IAAS\Database\Models\VirtualMachines;
 use NextDeveloper\IAAS\Http\Transformers\AbstractTransformers\AbstractVirtualMachinesTransformer;
-use NextDeveloper\IAAS\Services\VirtualMachinesService;
+
 
 /**
  * Class VirtualMachinesTransformer. This class is being used to manipulate the data we are serving to the customer
@@ -46,13 +46,6 @@ class VirtualMachinesTransformer extends AbstractVirtualMachinesTransformer
         unset($transformed['hypervisor_uuid']);
         unset($transformed['hypervisor_data']);
         unset($transformed['console_data']);
-
-        // Do not call getConsoleData() for draft VMs — it triggers HealthCheck when console_data is null
-        if ($model->is_draft) {
-            $transformed['console_data'] = null;
-        } else {
-            $transformed['console_data'] = VirtualMachinesService::getConsoleData($model);
-        }
 
         Cache::set(
             CacheHelper::getKey('VirtualMachines', $model->uuid, 'Transformed'),

--- a/src/Services/VirtualMachinesService.php
+++ b/src/Services/VirtualMachinesService.php
@@ -626,6 +626,11 @@ class VirtualMachinesService extends AbstractVirtualMachinesService
         $iv = config('iaas.console.iv');
         $t = time();
 
+        // Return early if console encryption is not configured
+        if (empty($key) || empty($iv)) {
+            return ['console' => 'Console encryption not configured (IAAS_CONSOLE_KEY / IAAS_CONSOLE_IV missing).'];
+        }
+
         $encrypt = function ($string) use ($key, $iv) {
             $method = 'AES-256-CBC';
             $output = openssl_encrypt($string, $method, $key, true, $iv);


### PR DESCRIPTION
## Summary
- Removes `getConsoleData()` call from `VirtualMachinesTransformer` — console data is now fetched directly via `/iaas/console/{uuid}`, so embedding it in the transformer response is no longer needed
- Guards `getConsoleData()` in `VirtualMachinesService` against missing `IAAS_CONSOLE_KEY` / `IAAS_CONSOLE_IV` config to prevent `openssl_encrypt(): Using an empty Initialization Vector` warning

## Test plan
- [ ] Confirm VM transformer response no longer includes `console_data`
- [ ] Confirm `/iaas/console/{uuid}` still returns console data correctly
- [ ] Confirm no openssl IV warnings in logs when console config is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)