### PR TITLE
feat: add agent_latest_ping field and heartbeat handler for VM agent telemetry

### DIFF
--- a/src/Console/Commands/ListenVmAgentEvents.php
+++ b/src/Console/Commands/ListenVmAgentEvents.php
@@ -59,6 +59,7 @@ class ListenVmAgentEvents extends Command
 
             match ($payload['type'] ?? '') {
                 'telemetry'    => $this->evaluateHealth($payload),
+                'heartbeat'    => $this->handleHeartbeat($payload),
                 'result'       => $this->handleResult($payload),
                 'capabilities' => $this->handleCapabilities($payload),
                 default        => Log::debug('[ListenVmAgentEvents] Unhandled message type', [
@@ -84,6 +85,36 @@ class ListenVmAgentEvents extends Command
 
         $this->info('Listener stopped.');
         return 0;
+    }
+
+    private function handleHeartbeat(array $payload): void
+    {
+        $agentUuid = $payload['agent_uuid'] ?? null;
+        $timestamp = $payload['timestamp']  ?? null;
+
+        if (!$agentUuid) {
+            Log::warning('[ListenVmAgentEvents] heartbeat missing agent_uuid');
+            return;
+        }
+
+        $vm = VirtualMachines::withoutGlobalScope(AuthorizationScope::class)
+            ->withoutGlobalScope(LimitScope::class)
+            ->where('uuid', $agentUuid)
+            ->first();
+
+        if (!$vm) {
+            Log::warning('[ListenVmAgentEvents] VM not found for heartbeat', ['agent_uuid' => $agentUuid]);
+            return;
+        }
+
+        $pingTime = $timestamp ? \Carbon\Carbon::createFromTimestamp($timestamp) : now();
+
+        VirtualMachinesService::update($vm->uuid, ['agent_latest_ping' => $pingTime]);
+
+        Log::debug('[ListenVmAgentEvents] VM heartbeat recorded', [
+            'agent_uuid'        => $agentUuid,
+            'agent_latest_ping' => $pingTime->toIso8601String(),
+        ]);
     }
 
     private function handleCapabilities(array $payload): void

--- a/src/Database/Models/VirtualMachines.php
+++ b/src/Database/Models/VirtualMachines.php
@@ -66,6 +66,7 @@ use NextDeveloper\Commons\Database\Traits\HasObject;
  * @property string $post_boot_script
  * @property $tokens
  * @property string $agent_api_key
+ * @property \Carbon\Carbon $agent_latest_ping
  */
 class VirtualMachines extends Model
 {
@@ -126,6 +127,7 @@ class VirtualMachines extends Model
             'post_boot_script',
             'tokens',
             'agent_api_key',
+            'agent_latest_ping',
     ];
 
     /**
@@ -192,6 +194,7 @@ class VirtualMachines extends Model
     'post_boot_script' => 'string',
     'tokens' => 'array',
     'agent_api_key' => 'string',
+    'agent_latest_ping' => 'datetime',
     ];
 
     /**
@@ -201,6 +204,7 @@ class VirtualMachines extends Model
      */
     protected $dates = [
     'last_metadata_request',
+    'agent_latest_ping',
     'created_at',
     'updated_at',
     'deleted_at',

--- a/src/Database/Models/VirtualMachinesPerspective.php
+++ b/src/Database/Models/VirtualMachinesPerspective.php
@@ -58,6 +58,7 @@ use NextDeveloper\Commons\Database\Traits\HasObject;
  * @property string $auto_backup_interval
  * @property string $auto_backup_time
  * @property string $post_boot_script
+ * @property \Carbon\Carbon $agent_latest_ping
  * @property string $maintainer
  * @property string $responsible
  * @property integer $iaas_compute_pool_id
@@ -122,6 +123,7 @@ class VirtualMachinesPerspective extends Model
             'auto_backup_interval',
             'auto_backup_time',
             'post_boot_script',
+            'agent_latest_ping',
             'maintainer',
             'responsible',
             'iaas_compute_pool_id',
@@ -188,6 +190,7 @@ class VirtualMachinesPerspective extends Model
     'auto_backup_interval' => 'string',
     'auto_backup_time' => 'string',
     'post_boot_script' => 'string',
+    'agent_latest_ping' => 'datetime',
     'maintainer' => 'string',
     'responsible' => 'string',
     'iaas_compute_pool_id' => 'integer',

--- a/src/Http/Transformers/AbstractTransformers/AbstractVirtualMachinesPerspectiveTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractVirtualMachinesPerspectiveTransformer.php
@@ -102,6 +102,7 @@ class AbstractVirtualMachinesPerspectiveTransformer extends AbstractTransformer
             'auto_backup_interval'  =>  $model->auto_backup_interval,
             'auto_backup_time'  =>  $model->auto_backup_time,
             'post_boot_script'  =>  $model->post_boot_script,
+            'agent_latest_ping'  =>  $model->agent_latest_ping,
             'maintainer'  =>  $model->maintainer,
             'responsible'  =>  $model->responsible,
             'iaas_compute_pool_id'  =>  $iaasComputePoolId ? $iaasComputePoolId->uuid : null,

--- a/src/Http/Transformers/AbstractTransformers/AbstractVirtualMachinesTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractVirtualMachinesTransformer.php
@@ -112,6 +112,7 @@ class AbstractVirtualMachinesTransformer extends AbstractTransformer
             'backup_repository_id'  =>  $backupRepositoryId ? $backupRepositoryId->uuid : null,
             'post_boot_script'  =>  $model->post_boot_script,
             'tokens'  =>  $model->tokens,
+            'agent_latest_ping'  =>  $model->agent_latest_ping,
             ]
         );
     }

--- a/src/Http/api.routes.php
+++ b/src/Http/api.routes.php
@@ -60,9 +60,6 @@ Route::prefix('iaas')->group(
                 Route::post('/', 'VirtualMachines\VirtualMachinesController@store');
                 Route::post('/{iaas_virtual_machines}/do/{action}', 'VirtualMachines\VirtualMachinesController@doAction');
 
-                Route::get('/{iaas_virtual_machines}/agent/operations', 'VirtualMachines\VirtualMachineAgentCommandsController@index');
-                Route::post('/{iaas_virtual_machines}/agent/{operation}', 'VirtualMachines\VirtualMachineAgentCommandsController@dispatch');
-
                 Route::patch('/{iaas_virtual_machines}', 'VirtualMachines\VirtualMachinesController@update');
                 Route::delete('/{iaas_virtual_machines}', 'VirtualMachines\VirtualMachinesController@destroy');
             }
@@ -2043,6 +2040,13 @@ Route::prefix('iaas')->group(
         );
 
         // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+
+        Route::prefix('virtual-machines')->group(
+            function () {
+                Route::get('/{iaas_virtual_machines}/agent/operations', 'VirtualMachines\VirtualMachineAgentCommandsController@index');
+                Route::post('/{iaas_virtual_machines}/agent/{operation}', 'VirtualMachines\VirtualMachineAgentCommandsController@dispatch');
+            }
+        );
 
         Route::prefix('virtual-machine-migrations')->group(
             function () {


### PR DESCRIPTION
## Summary
- Adds `agent_latest_ping` (timestamptz) to `VirtualMachines` and `VirtualMachinesPerspective` models (fillable, datetime cast, dates array, docblock)
- Exposes `agent_latest_ping` in both abstract transformers
- Adds `heartbeat` message type handler in `ListenVmAgentEvents` — updates `agent_latest_ping` from the protocol envelope `timestamp`
- Moves `VirtualMachineAgentCommandsController` routes below the `EDIT AFTER HERE` marker in `api.routes.php` to survive code regeneration

## Test plan
- [ ] Confirm `agent_latest_ping` appears in the VM transformer response
- [ ] Send a `heartbeat` NATS message to `agent.vm.{uuid}` and verify `agent_latest_ping` is updated on the VM
- [ ] Confirm agent routes still resolve correctly after the move

🤖 Generated with [Claude Code](https://claude.com/claude-code)