### PR TITLE
feat: encapsulate hypervisor allowed-operations under hypervisor key in available_operations

### DIFF
--- a/src/Actions/ComputeMembers/ScanVirtualMachines.php
+++ b/src/Actions/ComputeMembers/ScanVirtualMachines.php
@@ -125,7 +125,11 @@ class ScanVirtualMachines extends AbstractAction
                     'cpu'           =>  $vmInfo['VCPUs-max'],
                     'ram'           =>  $vmInfo['memory-static-max'] / 1024 / 1024, //  this comes in bytes, conterting to MB,
                     'status'        =>  $vmInfo['power-state'],
-                    'available_operations'  =>  $vmInfo['allowed-operations'],
+                    // Merge so that other keys (e.g. 'agent') set by other sources are not overwritten
+                    'available_operations'  =>  array_merge(
+                        $dbVm->available_operations ?? [],
+                        ['hypervisor' => $vmInfo['allowed-operations']]
+                    ),
                     'current_operations'    =>  $vmInfo['current-operations'],
                     'blocked_operations'    =>  $vmInfo['blocked-operations'],
                     'hypervisor_uuid'       =>  $vm['uuid'],
@@ -157,7 +161,7 @@ class ScanVirtualMachines extends AbstractAction
                     'cpu'           =>  $vmInfo['VCPUs-max'],
                     'ram'           =>  $vmInfo['memory-static-max'] / 1024 / 1024, //  this comes in bytes, conterting to MB,
                     'status'        =>  $vmInfo['power-state'],
-                    'available_operations'  =>  $vmInfo['allowed-operations'],
+                    'available_operations'  =>  ['hypervisor' => $vmInfo['allowed-operations']],
                     'current_operations'    =>  $vmInfo['current-operations'],
                     'blocked_operations'    =>  $vmInfo['blocked-operations'],
                     'hypervisor_uuid'       =>  $vm['uuid'],


### PR DESCRIPTION
## Summary
- `available_operations` now stores operations by source key: `{ "hypervisor": [...], "agent": [...] }`
- **Update path**: uses `array_merge` on the existing value so other keys (e.g. `agent`, populated by the NATS heartbeat listener) are not overwritten
- **Create path**: initialises as `["hypervisor" => [...]]`

## Test plan
- [ ] Scan a compute member and confirm `available_operations` has the `hypervisor` key
- [ ] Confirm a subsequent scan does not wipe an existing `agent` key on the VM

🤖 Generated with [Claude Code](https://claude.com/claude-code)