### PR TITLE
fix: wrap agent_latest_ping and available_operations updates in runAsAdmin

### DIFF
--- a/src/Console/Commands/ListenVmAgentEvents.php
+++ b/src/Console/Commands/ListenVmAgentEvents.php
@@ -127,7 +127,7 @@ class ListenVmAgentEvents extends Command
 
         $pingTime = $timestamp ? \Carbon\Carbon::createFromTimestamp($timestamp) : now();
 
-        VirtualMachinesService::update($vm->uuid, ['agent_latest_ping' => $pingTime]);
+        UserHelper::runAsAdmin(fn () => VirtualMachinesService::update($vm->uuid, ['agent_latest_ping' => $pingTime]));
 
         Log::info('[ListenVmAgentEvents] VM heartbeat recorded', [
             'agent_uuid'        => $agentUuid,
@@ -191,8 +191,7 @@ class ListenVmAgentEvents extends Command
         $existing           = $vm->available_operations ?? [];
         $existing['agent']  = $operations;
 
-        UserHelper::setAdminAsCurrentUser();
-        VirtualMachinesService::update($vm->uuid, ['available_operations' => $existing]);
+        UserHelper::runAsAdmin(fn () => VirtualMachinesService::update($vm->uuid, ['available_operations' => $existing]));
 
         Log::info('[ListenVmAgentEvents] VM capabilities updated', [
             'agent_uuid' => $agentUuid,


### PR DESCRIPTION
## Summary
- `agent_latest_ping` update in `handleHeartbeat` was missing admin context — field was never persisted. Now wrapped in `UserHelper::runAsAdmin()`.
- `available_operations` update in `handleCapabilities` replaced bare `setAdminAsCurrentUser()` + update with the cleaner `runAsAdmin` closure pattern.

## Test plan
- [ ] Send a heartbeat and confirm `agent_latest_ping` is updated in the database
- [ ] Send a capabilities message and confirm `available_operations['agent']` is persisted

🤖 Generated with [Claude Code](https://claude.com/claude-code)