### PR TITLE
feat: add sync agent command endpoint and fix null VM guards

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "php": ">=8.2.0",
         "league/fractal": "*",
         "monolog/monolog": "*",
-        "markrogoyski/ipv4-subnet-calculator": "4.*"
+        "markrogoyski/ipv4-subnet-calculator": "4.*",
+        "nextdeveloper/events": ">=1.2.0"
     },
     "require-dev": {
         "illuminate/support": ">=8.0",

--- a/src/Http/Controllers/VirtualMachines/VirtualMachineAgentCommandsController.php
+++ b/src/Http/Controllers/VirtualMachines/VirtualMachineAgentCommandsController.php
@@ -3,6 +3,8 @@
 namespace NextDeveloper\IAAS\Http\Controllers\VirtualMachines;
 
 use Illuminate\Http\Request;
+use NextDeveloper\Events\Exceptions\AgentTimeoutException;
+use NextDeveloper\Events\Services\AgentCommandService;
 use NextDeveloper\IAAS\Http\Controllers\AbstractController;
 use NextDeveloper\IAAS\Services\VirtualMachinesService;
 use NextDeveloper\IAAS\Services\VmAgentCommandService;
@@ -10,8 +12,9 @@ use NextDeveloper\IAAS\Services\VmAgentCommandService;
 /**
  * Exposes VM agent commands over HTTP.
  *
- * GET  /{vm}/agent/operations        — list operations available for this VM
- * POST /{vm}/agent/{operation}       — dispatch a command, returns 202 with command UUID
+ * GET  /{vm}/agent/operations           — list operations available for this VM
+ * POST /{vm}/agent/{operation}          — run a command async, returns 202 with command UUID
+ * POST /{vm}/agent/{operation}/sync     — send a command and block until the agent replies
  */
 class VirtualMachineAgentCommandsController extends AbstractController
 {
@@ -22,6 +25,10 @@ class VirtualMachineAgentCommandsController extends AbstractController
     {
         $vm = VirtualMachinesService::getByRef($vmId);
 
+        if (!$vm) {
+            return $this->setStatusCode(404)->withError('Virtual machine not found.', 'ERROR-VM-NOT-FOUND');
+        }
+
         return $this->withArray([
             'vm_uuid'    => $vm->uuid,
             'operations' => VmAgentCommandService::getAvailableOperations($vm),
@@ -29,13 +36,18 @@ class VirtualMachineAgentCommandsController extends AbstractController
     }
 
     /**
-     * Dispatch a command to the VM agent asynchronously.
+     * Run a command on the VM agent asynchronously.
      * Returns 202 immediately with a command UUID the caller can poll via
      * GET /events/agent-commands/{command_uuid}.
      */
-    public function dispatch(Request $request, $vmId, $operation)
+    public function run(Request $request, $vmId, $operation)
     {
-        $vm     = VirtualMachinesService::getByRef($vmId);
+        $vm = VirtualMachinesService::getByRef($vmId);
+
+        if (!$vm) {
+            return $this->setStatusCode(404)->withError('Virtual machine not found.', 'ERROR-VM-NOT-FOUND');
+        }
+
         $params = $request->except(['_token']);
 
         try {
@@ -51,6 +63,41 @@ class VirtualMachineAgentCommandsController extends AbstractController
         return $this->setStatusCode(202)->withArray([
             'command_uuid' => $commandUuid,
             'status'       => 'sent',
+        ]);
+    }
+
+    /**
+     * Send a command to the VM agent and block until the agent replies.
+     * Returns 200 with the agent's result, or 504 on timeout.
+     */
+    public function send(Request $request, $vmId, $operation)
+    {
+        $vm = VirtualMachinesService::getByRef($vmId);
+
+        if (!$vm) {
+            return $this->setStatusCode(404)->withError('Virtual machine not found.', 'ERROR-VM-NOT-FOUND');
+        }
+
+        $params  = $request->except(['_token', 'timeout_s']);
+        $timeout = (int) $request->input('timeout_s', 10);
+
+        try {
+            $result = app(AgentCommandService::class)->send(
+                agentUuid:      $vm->uuid,
+                operation:      $operation,
+                params:         $params,
+                timeoutSeconds: $timeout
+            );
+        } catch (AgentTimeoutException $e) {
+            return $this->setStatusCode(504)->withError(
+                $e->getMessage(),
+                'ERROR-AGENT-TIMEOUT'
+            );
+        }
+
+        return $this->withArray([
+            'operation' => $operation,
+            'result'    => $result,
         ]);
     }
 }

--- a/src/Http/api.routes.php
+++ b/src/Http/api.routes.php
@@ -2044,7 +2044,8 @@ Route::prefix('iaas')->group(
         Route::prefix('virtual-machines')->group(
             function () {
                 Route::get('/{iaas_virtual_machines}/agent/operations', 'VirtualMachines\VirtualMachineAgentCommandsController@index');
-                Route::post('/{iaas_virtual_machines}/agent/{operation}', 'VirtualMachines\VirtualMachineAgentCommandsController@dispatch');
+                Route::post('/{iaas_virtual_machines}/agent/{operation}', 'VirtualMachines\VirtualMachineAgentCommandsController@run');
+                Route::post('/{iaas_virtual_machines}/agent/{operation}/sync', 'VirtualMachines\VirtualMachineAgentCommandsController@send');
             }
         );
 


### PR DESCRIPTION
## Summary
- Adds `POST /{vm}/agent/{operation}/sync` — sends a command to the VM agent and blocks until it replies, returning the result directly (200) or 504 on timeout
- Renames `dispatch()` → `run()` in the controller to avoid `FatalError` conflict with `AbstractController::dispatch($job)` from Laravel's `DispatchesJobs` trait
- Adds `404` null guards in all three controller methods (`index`, `run`, `send`) for missing VMs
- Adds `nextdeveloper/events: >=1.2.0` to `composer.json` so `AgentCommandService` and `AgentTimeoutException` are properly resolved
- Registers the sync route in `api.routes.php` below the `EDIT AFTER HERE` marker

## Test plan
- [ ] `GET /iaas/virtual-machines/{uuid}/agent/operations` returns available operations
- [ ] `POST /iaas/virtual-machines/{uuid}/agent/{op}` returns 202 with command UUID
- [ ] `POST /iaas/virtual-machines/{uuid}/agent/{op}/sync` returns the agent result directly
- [ ] Invalid VM UUID returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)