### PR TITLE
fix: only dispatch Commit when VM is draft or pending-update

### DIFF
--- a/src/Services/VirtualMachinesService.php
+++ b/src/Services/VirtualMachinesService.php
@@ -514,8 +514,10 @@ class VirtualMachinesService extends AbstractVirtualMachinesService
             dispatch(new GenerateCloudInitImage($vm));
         }
 
-        if ($vm->hypervisor_uuid) {
-            dispatch(new Commit($vm));
+        // Only commit when the VM actually needs re-provisioning — mirrors the guard
+        // inside Commit::handle() so we never queue a job that would immediately return.
+        if ($vm->hypervisor_uuid && ($updatedVm->is_draft || $updatedVm->status === 'pending-update')) {
+            dispatch(new Commit($updatedVm));
         }
 
         return $updatedVm;


### PR DESCRIPTION
## Summary
Every `VirtualMachinesService::update()` call on a VM that has a `hypervisor_uuid` was dispatching a `Commit` job — including heartbeat `agent_latest_ping` writes and `available_operations` capability updates. This flooded the `iaas` queue with no-op jobs (they returned immediately due to the same guard already inside `Commit::handle()`).

**Root cause:** The dispatch condition `if ($vm->hypervisor_uuid)` was too broad.

**Fix:** Mirrors the guard inside `Commit::handle()` — only dispatch when the VM is actually in a state that requires re-provisioning: `is_draft = true` or `status = pending-update`.

## Test plan
- [ ] Update a running VM's `agent_latest_ping` — confirm no Commit job is queued
- [ ] Update a VM's CPU/RAM — confirm status becomes `pending-update` and Commit is dispatched
- [ ] Create and commit a new draft VM — confirm Commit still dispatches correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)