### PR TITLE
debug: remove Commit dispatch from update() entirely to isolate loop root cause

### DIFF
--- a/src/Services/VirtualMachinesService.php
+++ b/src/Services/VirtualMachinesService.php
@@ -514,12 +514,6 @@ class VirtualMachinesService extends AbstractVirtualMachinesService
             dispatch(new GenerateCloudInitImage($vm));
         }
 
-        // Only commit when this update explicitly set status to pending-update (CPU/RAM resize).
-        // All other updates (agent pings, capabilities, tags, etc.) must NOT trigger a commit.
-        if ($updatedVm->status === 'pending-update') {
-            dispatch(new Commit($updatedVm));
-        }
-
         return $updatedVm;
     }
 


### PR DESCRIPTION
## Summary
Removed the `Commit` dispatch from `VirtualMachinesService::update()` entirely to determine whether this is the root cause of the recurring loop. If the loop stops, the dispatch needs to be re-wired at a higher level. If it continues, the loop originates elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)