### PR TITLE
fix: strip LimitScope in syncFromToolkit so it sees all existing roles

### DIFF
--- a/src/Services/AnsibleRolesService.php
+++ b/src/Services/AnsibleRolesService.php
@@ -6,6 +6,7 @@ use NextDeveloper\IAAS\Database\Models\AnsibleRoles;
 use NextDeveloper\IAAS\Database\Models\AnsibleServers;
 use NextDeveloper\IAAS\Exceptions\UnknownServiceRoleException;
 use NextDeveloper\IAAS\Services\AbstractServices\AbstractAnsibleRolesService;
+use NextDeveloper\Commons\Database\GlobalScopes\LimitScope;
 use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
 use NextDeveloper\IAM\Helpers\UserHelper;
 
@@ -118,7 +119,12 @@ class AnsibleRolesService extends AbstractAnsibleRolesService
         $reactivated = [];
         $deactivated = [];
 
+        //  Both withoutGlobalScope() calls here strip LimitScope alongside AuthorizationScope -
+        //  LimitScope (see config('iaas.scopes.global')) silently caps every query at
+        //  $model->perPage (20) rows, so without it any discovered/stale set past the 20th row
+        //  would look "not found" and get recreated/left active instead of updated/deactivated.
         $existingRoles = AnsibleRoles::withoutGlobalScope(AuthorizationScope::class)
+            ->withoutGlobalScope(LimitScope::class)
             ->whereIn('name', $discoveredNames)
             ->get()
             ->keyBy('name');
@@ -177,6 +183,7 @@ class AnsibleRolesService extends AbstractAnsibleRolesService
         }
 
         $staleRoles = AnsibleRoles::withoutGlobalScope(AuthorizationScope::class)
+            ->withoutGlobalScope(LimitScope::class)
             ->where('is_active', true)
             ->whereNotIn('name', $discoveredNames)
             ->get();


### PR DESCRIPTION
## Summary
- `AnsibleRoles` applies `LimitScope` globally (`config('iaas.scopes.global')`), which silently adds `->limit($model->perPage)` (20 for this model) to every query.
- `syncFromToolkit()`'s existing-role and stale-role lookups only stripped `AuthorizationScope`, so once more than 20 service-role names are discovered (or more than 20 roles are stale), rows past the 20th looked "not found": already-existing roles got recreated instead of updated, and stale roles past #20 never got deactivated.
- Fix: strip `LimitScope` too in both queries.

## Test plan
- [x] php -l on changed file